### PR TITLE
[TASK-40193] feat: AU → US Content Convertor | Implement Localisation Infa in NeoGo

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v4
         with:
-          go-version: '1.20'
+          go-version: '1.22'
       - name: Install dependencies
         run: |
           go mod download
@@ -37,7 +37,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v4
         with:
-          go-version: '1.20'
+          go-version: '1.22'
           cache: false
       - name: Install dependencies
         run: |

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -5,6 +5,7 @@ vars:
   NEO4J_PORT: 7687
   NEO4J_USER: neo4j
   NEO4J_PASSWORD: password
+  NEO4J_IMAGE: neo4j:5.15.0
 
 tasks:
   check:
@@ -63,7 +64,7 @@ tasks:
             -e NEO4J_PLUGINS='["apoc"]' \
             -e NEO4J_ACCEPT_LICENSE_AGREEMENT=yes \
             --rm \
-            neo4j:5.7-community
+            {{.NEO4J_IMAGE}}
           echo "Neo4J container started successfully"
         else
           echo "Neo4J container is already running"
@@ -153,4 +154,3 @@ tasks:
       - task: neo4j:start
       - task: neo4j:wait
       - echo "Development environment ready!"
-

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -5,7 +5,6 @@ vars:
   NEO4J_PORT: 7687
   NEO4J_USER: neo4j
   NEO4J_PASSWORD: password
-  NEO4J_IMAGE: neo4j:5.15.0
 
 tasks:
   check:
@@ -64,7 +63,7 @@ tasks:
             -e NEO4J_PLUGINS='["apoc"]' \
             -e NEO4J_ACCEPT_LICENSE_AGREEMENT=yes \
             --rm \
-            {{.NEO4J_IMAGE}}
+            neo4j:5.7-community
           echo "Neo4J container started successfully"
         else
           echo "Neo4J container is already running"
@@ -154,3 +153,4 @@ tasks:
       - task: neo4j:start
       - task: neo4j:wait
       - echo "Development environment ready!"
+

--- a/canonicalize_params_test.go
+++ b/canonicalize_params_test.go
@@ -1,0 +1,139 @@
+package neogo
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testLocale struct {
+	EnUS string `db:"enUS"`
+	EnAU string `db:"enAU"`
+}
+
+type testDBStruct struct {
+	Title       string      `db:"title"`
+	TitleLocale *testLocale `db:"title,flatten"`
+	Ignored     string      `json:"-"`
+}
+
+type testJSONStruct struct {
+	Name  string `json:"name"`
+	Count int    `json:"count"`
+}
+
+type testNoTagStruct struct {
+	Name  string
+	Count int
+}
+
+type testEmbeddedBase struct {
+	Code string `db:"code"`
+}
+
+type testEmbeddedStruct struct {
+	testEmbeddedBase
+	Name string `db:"name"`
+}
+
+func TestCanonicalizeParams(t *testing.T) {
+	t.Run("struct with db tags uses PropsFromStruct", func(t *testing.T) {
+		input := testDBStruct{
+			Title: "Hello",
+			TitleLocale: &testLocale{
+				EnUS: "Hello-US",
+				EnAU: "Hello-AU",
+			},
+			Ignored: "skip",
+		}
+		params, err := canonicalizeParams(map[string]any{"props": input})
+		require.NoError(t, err)
+		assert.Equal(t, map[string]any{
+			"props": map[string]any{
+				"title":      "Hello",
+				"title_enUS": "Hello-US",
+				"title_enAU": "Hello-AU",
+			},
+		}, params)
+	})
+
+	t.Run("pointer to struct with db tags uses PropsFromStruct", func(t *testing.T) {
+		input := &testDBStruct{
+			Title: "Hello",
+			TitleLocale: &testLocale{
+				EnUS: "Hello-US",
+			},
+		}
+		params, err := canonicalizeParams(map[string]any{"props": input})
+		require.NoError(t, err)
+		assert.Equal(t, map[string]any{
+			"props": map[string]any{
+				"title":      "Hello",
+				"title_enUS": "Hello-US",
+			},
+		}, params)
+	})
+
+	t.Run("nil pointer struct becomes nil", func(t *testing.T) {
+		var input *testDBStruct
+		params, err := canonicalizeParams(map[string]any{"props": input})
+		require.NoError(t, err)
+		assert.Equal(t, map[string]any{"props": nil}, params)
+	})
+
+	t.Run("struct with json tags uses PropsFromStruct and omits zero values", func(t *testing.T) {
+		input := testJSONStruct{Name: "Alpha"}
+		params, err := canonicalizeParams(map[string]any{"props": input})
+		require.NoError(t, err)
+		assert.Equal(t, map[string]any{
+			"props": map[string]any{"name": "Alpha"},
+		}, params)
+	})
+
+	t.Run("struct without tags uses JSON marshal", func(t *testing.T) {
+		input := testNoTagStruct{Name: "Alpha", Count: 2}
+		params, err := canonicalizeParams(map[string]any{"props": input})
+		require.NoError(t, err)
+		assert.Equal(t, map[string]any{
+			"props": map[string]any{
+				"Name":  "Alpha",
+				"Count": float64(2),
+			},
+		}, params)
+	})
+
+	t.Run("unexported embedded struct fields are skipped", func(t *testing.T) {
+		input := testEmbeddedStruct{
+			testEmbeddedBase: testEmbeddedBase{Code: "X"},
+			Name:             "Alpha",
+		}
+		params, err := canonicalizeParams(map[string]any{"props": input})
+		require.NoError(t, err)
+		assert.Equal(t, map[string]any{
+			"props": map[string]any{
+				"name": "Alpha",
+			},
+		}, params)
+	})
+
+	t.Run("map uses JSON marshal", func(t *testing.T) {
+		params, err := canonicalizeParams(map[string]any{
+			"props": map[string]any{"count": 2},
+		})
+		require.NoError(t, err)
+		assert.Equal(t, map[string]any{
+			"props": map[string]any{"count": float64(2)},
+		}, params)
+	})
+
+	t.Run("slice uses JSON marshal", func(t *testing.T) {
+		params, err := canonicalizeParams(map[string]any{
+			"props": []int{1, 2},
+		})
+		require.NoError(t, err)
+		assert.Equal(t, map[string]any{
+			"props": []any{float64(1), float64(2)},
+		}, params)
+	})
+}

--- a/client_test.go
+++ b/client_test.go
@@ -2,6 +2,7 @@ package neogo
 
 import (
 	"context"
+	"errors"
 	"reflect"
 	"testing"
 
@@ -873,11 +874,11 @@ func TestResultImpl(t *testing.T) {
 		})
 
 		t.Run("should throw error when there is error in resultWithContext", func(t *testing.T) {
-			var n []any
+			var n int
 			c := internal.NewCypherClient()
 			cy, err := c.
-				Match(db.Node(db.Var(n, db.Name("n")))).
-				Return(n).
+				Unwind("range(0, 1)", "i").
+				Return(db.Qual(&n, "i")).
 				Compile()
 			assert.NoError(t, err)
 			params, err := canonicalizeParams(cy.Parameters)
@@ -890,6 +891,9 @@ func TestResultImpl(t *testing.T) {
 				assert.NoError(t, err)
 				_, resultErr := result.Single(ctx)
 				assert.Error(t, resultErr)
+				if resultErr == nil {
+					resultErr = errors.New("expected error from result.Single")
+				}
 
 				var res query.Result = &resultImpl{
 					ResultWithContext: result,

--- a/internal/scope.go
+++ b/internal/scope.go
@@ -527,7 +527,7 @@ func (s *Scope) register(value any, lookup bool, isNode *bool) *member {
 				innerT := value.Type()
 				for i := 0; i < innerT.NumField(); i++ {
 					f := value.Field(i)
-					if !f.IsValid() || !f.CanInterface() || f.IsZero() {
+					if !f.IsValid() || !f.CanInterface() {
 						continue
 					}
 					fT := innerT.Field(i)
@@ -545,6 +545,9 @@ func (s *Scope) register(value any, lookup bool, isNode *bool) *member {
 						if err := ValidateFlattenType(fT.Type); err != nil {
 							panic(err)
 						}
+						if f.IsZero() {
+							continue
+						}
 						flattenPrefix := tag.Name
 						if flattenPrefix == "" {
 							flattenPrefix = DefaultPropName(fT.Name)
@@ -553,6 +556,9 @@ func (s *Scope) register(value any, lookup bool, isNode *bool) *member {
 							continue
 						}
 						bindFieldsFrom(f, JoinPrefix(prefix, flattenPrefix))
+						continue
+					}
+					if f.IsZero() {
 						continue
 					}
 					name := tag.Name

--- a/internal/scope.go
+++ b/internal/scope.go
@@ -290,7 +290,10 @@ func (s *Scope) bindFieldsWithPrefix(strct reflect.Value, memberName, prefix str
 		if !hasTag {
 			// Recurse into composite fields
 			if vfT.Anonymous {
-				s.bindFieldsWithPrefix(vf, memberName, prefix)
+				inner := derefAll(vf)
+				if inner.IsValid() && inner.Kind() == reflect.Struct {
+					s.bindFieldsWithPrefix(inner, memberName, prefix)
+				}
 			}
 			continue
 		}

--- a/internal/scope_test.go
+++ b/internal/scope_test.go
@@ -8,8 +8,25 @@ import (
 )
 
 type Person struct {
-	Node `neo4j:"Person"`
-	Name string `json:"name"`
+	Node       `neo4j:"Person"`
+	Name       string  `json:"name"`
+	NameLocale Locales `json:"name,flatten"`
+}
+
+type Locales struct {
+	EnUS string `json:"enUS"`
+}
+
+type nestedOuter struct {
+	Inner nestedInner `json:"outer,flatten"`
+}
+
+type nestedInner struct {
+	Leaf nestedLeaf `json:"inner,flatten"`
+}
+
+type nestedLeaf struct {
+	Value string `json:"value"`
 }
 
 func TestBindFields(t *testing.T) {
@@ -26,10 +43,23 @@ func TestBindFields(t *testing.T) {
 				identifier: "p",
 				name:       "name",
 			},
+			reflect.ValueOf(&p.NameLocale.EnUS).Pointer(): {
+				identifier: "p",
+				name:       "name_enUS",
+			},
 		}, s.fields)
 		require.Equal(t, map[reflect.Value]string{
-			reflect.ValueOf(&p.ID):   "p.id",
-			reflect.ValueOf(&p.Name): "p.name",
+			reflect.ValueOf(&p.ID):              "p.id",
+			reflect.ValueOf(&p.Name):            "p.name",
+			reflect.ValueOf(&p.NameLocale.EnUS): "p.name_enUS",
 		}, s.names)
+	})
+
+	t.Run("binds nested flatten fields", func(t *testing.T) {
+		outer := &nestedOuter{}
+		s := newScope()
+		s.bindFields(reflect.ValueOf(outer).Elem(), "o")
+		leafPtr := reflect.ValueOf(&outer.Inner.Leaf.Value)
+		require.Equal(t, "o.outer_inner_value", s.names[leafPtr])
 	})
 }

--- a/internal/scope_test.go
+++ b/internal/scope_test.go
@@ -62,4 +62,18 @@ func TestBindFields(t *testing.T) {
 		leafPtr := reflect.ValueOf(&outer.Inner.Leaf.Value)
 		require.Equal(t, "o.outer_inner_value", s.names[leafPtr])
 	})
+
+	t.Run("ignores nil anonymous pointer", func(t *testing.T) {
+		type Embedded struct {
+			Value string `json:"value"`
+		}
+		type Wrapper struct {
+			*Embedded
+		}
+		w := &Wrapper{}
+		s := newScope()
+		require.NotPanics(t, func() {
+			s.bindFields(reflect.ValueOf(w).Elem(), "w")
+		})
+	})
 }

--- a/internal/tests/common.go
+++ b/internal/tests/common.go
@@ -31,6 +31,9 @@ func Check(t *testing.T, cy *internal.CompiledCypher, err error, want internal.C
 }
 
 type (
+	Locales struct {
+		EnUS string `db:"enUS" json:"enUS"`
+	}
 	Movie struct {
 		internal.Node `neo4j:"Movie"`
 
@@ -42,6 +45,7 @@ type (
 		internal.Node `neo4j:"Person"`
 
 		Name          string  `json:"name"`
+		NameLocale    Locales `db:"name,flatten"`
 		Surname       string  `json:"surname"`
 		Position      string  `json:"position"`
 		Email         string  `json:"email"`

--- a/internal/tests/create_test.go
+++ b/internal/tests/create_test.go
@@ -220,7 +220,10 @@ func TestCreate(t *testing.T) {
 		t.Run("Create node with a parameter for the properties", func(t *testing.T) {
 			c := internal.NewCypherClient()
 			n := Person{
-				Name:     "Andy",
+				Name: "Andy",
+				NameLocale: Locales{
+					EnUS: "Anders",
+				},
 				Position: "Developer",
 			}
 			cy, err := c.
@@ -230,12 +233,13 @@ func TestCreate(t *testing.T) {
 
 			Check(t, cy, err, internal.CompiledCypher{
 				Cypher: `
-					CREATE (n:Person {name: $n_name, position: $n_position})
+					CREATE (n:Person {name: $n_name, name_enUS: $n_name_enUS, position: $n_position})
 					RETURN n
 					`,
 				Parameters: map[string]any{
-					"n_name":     n.Name,
-					"n_position": n.Position,
+					"n_name":      n.Name,
+					"n_name_enUS": n.NameLocale.EnUS,
+					"n_position":  n.Position,
 				},
 				Bindings: map[string]reflect.Value{
 					"n": reflect.ValueOf(&n),

--- a/props.go
+++ b/props.go
@@ -1,0 +1,98 @@
+package neogo
+
+import (
+	"fmt"
+	"reflect"
+
+	"github.com/rlch/neogo/internal"
+)
+
+func PropsFromStruct(value any) (map[string]any, error) {
+	v := reflect.ValueOf(value)
+	for v.Kind() == reflect.Ptr {
+		if v.IsNil() {
+			return map[string]any{}, nil
+		}
+		v = v.Elem()
+	}
+	if v.Kind() != reflect.Struct {
+		return nil, fmt.Errorf("props value must be a struct, got %s", v.Kind())
+	}
+
+	props := make(map[string]any)
+	if err := collectProps(v, "", props); err != nil {
+		return nil, err
+	}
+	return props, nil
+}
+
+func collectProps(value reflect.Value, prefix string, props map[string]any) error {
+	value = derefAll(value)
+	if !value.IsValid() || value.Kind() != reflect.Struct {
+		return nil
+	}
+
+	valueT := value.Type()
+	for i := 0; i < valueT.NumField(); i++ {
+		fv := value.Field(i)
+		ft := valueT.Field(i)
+		if ft.PkgPath != "" {
+			continue
+		}
+
+		tag, hasTag := internal.PropTagForField(ft)
+		if hasTag && tag.Ignore {
+			continue
+		}
+		if !hasTag {
+			if ft.Anonymous {
+				if err := collectProps(fv, prefix, props); err != nil {
+					return err
+				}
+			}
+			continue
+		}
+		if tag.Flatten {
+			if err := internal.ValidateFlattenType(ft.Type); err != nil {
+				return err
+			}
+			if fv.Kind() == reflect.Ptr && fv.IsNil() {
+				continue
+			}
+			if fv.IsZero() {
+				continue
+			}
+			flattenPrefix := tag.Name
+			if flattenPrefix == "" {
+				flattenPrefix = internal.DefaultPropName(ft.Name)
+			}
+			if err := collectProps(fv, internal.JoinPrefix(prefix, flattenPrefix), props); err != nil {
+				return err
+			}
+			continue
+		}
+		if fv.IsZero() {
+			continue
+		}
+		name := tag.Name
+		if name == "" {
+			name = internal.DefaultPropName(ft.Name)
+		}
+		key := internal.JoinPrefix(prefix, name)
+		if _, exists := props[key]; exists {
+			return fmt.Errorf("duplicate property key: %s", key)
+		}
+		props[key] = fv.Interface()
+	}
+	return nil
+}
+
+func derefAll(value reflect.Value) reflect.Value {
+	for value.IsValid() && value.Kind() == reflect.Ptr {
+		if value.IsNil() {
+			return reflect.Value{}
+		}
+		value = value.Elem()
+	}
+	return value
+}


### PR DESCRIPTION
## Implementation

Introduce generic flatten tag support across bindings:
- parse `db`/`json` tags into normalized prop tags
- recurse flattened structs with prefix joins (`name_enUS`, `outer_inner_value`)
- safely handle nil anonymous pointers
- bind map props into flattened structs with collision checks

## Changes (Feature)

- `internal/tags.go`: prop tag parsing + flatten helpers + validation
- `internal/scope.go`: flatten-aware binding with prefix handling
- `registry.go`: map-prop binding into flattened structs with collision detection
- Tests in `internal/*` and `registry_test.go` updated for flatten behavior

## Changes (Unrelated/CI Hygiene)

- `client_test.go`: stabilize ResultImpl error assertion to avoid nil error edge-case
- `integration.yml`: bump Go version to 1.22 for CI to compile modern Go features